### PR TITLE
Hotfix/1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.3] - 2025-03-25
 
-- Add missing `restart` for serer and agents
+- Add missing `restart` for server and agents
 - Add missing `depends_on` for agents with override for standalone agent hosting
 
 ## [1.1.2] - 2025-03-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.2] - 2025-03-25
+## [1.1.3] - 2025-03-25
 
 - Add missing `restart` for serer and agents
 - Add missing `depends_on` for agents with override for standalone agent hosting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2025-03-25
+
+- Add missing `restart` for serer and agents
+- Add missing `depends_on` for agents with override for standalone agent hosting
+
 ## [1.1.2] - 2025-03-10
 
 - Fix traefik labels for exposing agent endpoint 

--- a/docker-compose.agent.standalone.yml
+++ b/docker-compose.agent.standalone.yml
@@ -1,0 +1,3 @@
+services:
+  woodpecker-agent-1:
+    depends_on: !reset null

--- a/docker-compose.agent.yml
+++ b/docker-compose.agent.yml
@@ -15,6 +15,7 @@ services:
       woodpecker:
         condition: service_healthy
     command: agent
+    restart: always
     volumes:
       - .docker/data/agent/1:/etc/woodpecker
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.agent.yml
+++ b/docker-compose.agent.yml
@@ -11,6 +11,9 @@ services:
     networks:
       - app
       - frontend
+    depends_on:
+      woodpecker:
+        condition: service_healthy
     command: agent
     volumes:
       - .docker/data/agent/1:/etc/woodpecker

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -8,6 +8,7 @@ networks:
 services:
   woodpecker:
     image: woodpeckerci/woodpecker-server:${COMPOSE_SERVER_TAG}
+    restart: always
     networks:
       - app
       - frontend


### PR DESCRIPTION
https://leantime.itkdev.dk/dashboard/show#/tickets/showTicket/4124

## [1.1.3] - 2025-03-25

- Add missing `restart` for server and agents
- Add missing `depends_on` for agents with override for standalone agent hosting