### PR TITLE
Hotfix/1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.4] - 2025-03-25
+
+- Fix `depends_on` reset not respected by `extends`, sp must be duplicated
+
 ## [1.1.3] - 2025-03-25
 
 - Add missing `restart` for server and agents

--- a/docker-compose.agent.standalone.yml
+++ b/docker-compose.agent.standalone.yml
@@ -1,3 +1,12 @@
 services:
   woodpecker-agent-1:
-    depends_on: !reset null
+    depends_on: !reset []
+
+  woodpecker-agent-2:
+    depends_on: !reset []
+
+  woodpecker-agent-3:
+    depends_on: !reset []
+
+  woodpecker-agent-4:
+    depends_on: !reset []


### PR DESCRIPTION
https://leantime.itkdev.dk/dashboard/show#/tickets/showTicket/4124

## [1.1.4] - 2025-03-25

- Fix `depends_on` reset not respected by `extends`, sp must be duplicated